### PR TITLE
feat: Update Ruby buildpack to support Ruby 3.4

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,72 @@
+# Gemini Code Understanding
+
+
+## Role
+
+You are a senior engineer in the team. Given a prompt with a URL link which has language specific features and a request to update the code-base specific to that language version, your task is to update this code base to make sure that the Builders continue to work fine. Update the tests as you see fit but do not worry about running any `bazel` commands to validate. Do not worry about the language of the source code base itself which is written in Golang.
+
+Before makign any changes, you are to check out a new branch using git and then apply all the changes to that branch. Commit the changes to the branch and create a pull-request to the provided GitHub repository, once all the changes are done.
+
+You are to use MCP servers for Git and GitHub, when available.
+
+## Directory Structure
+
+The project is organized into three main directories: `cmd/`, `pkg/`, and `builders/`.
+
+### `cmd/`
+
+This directory contains the main entry points for the buildpack executables. Each subdirectory corresponds to a specific buildpack or a utility command. The code in this directory is responsible for parsing command-line arguments and invoking the appropriate logic from the `pkg/` directory.
+
+Each subdirectory in `cmd/` corresponds to a buildpack and contains a `main.go` file that serves as the entry point for that buildpack. The buildpacks are responsible for a specific part of the build process, such as setting up the runtime, installing dependencies, or configuring the entrypoint.
+
+- **Language-specific commands**: `cmd/cpp`, `cmd/dart`, `cmd/dotnet`, `cmd/go`, `cmd/java`, `cmd/nodejs`, `cmd/php`, `cmd/python`, `cmd/ruby` contain the main applications for the corresponding language buildpacks. These are further broken down into subdirectories for specific tasks, such as `runtime`, `sdk`, `appengine`, `functions-framework`, etc.
+- **Utility commands**: `cmd/config`, `cmd/utils` provide helper utilities. For example, `cmd/config/entrypoint` defines the entrypoint for the application, and `cmd/utils/archive-source` archives the source code.
+- **Firebase commands**: `cmd/firebase` contains commands specific to Firebase deployments, such as `preparer` and `publisher`.
+
+### `pkg/`
+
+This directory contains the core logic and libraries for the buildpacks. The code is organized into reusable packages, each with a specific responsibility.
+
+- **`gcpbuildpack`**: The core framework for creating buildpacks. It provides the main entry point, context, and functions for buildpack lifecycle phases (detect, build), layer management, and execution.
+- **Language-specific logic**:
+    - `pkg/golang`: Provides Go-specific build logic, including version resolution, workspace setup, and dependency management.
+    - `pkg/java`: Contains Java build logic, with support for Maven and Gradle. It handles JAR discovery, manifest parsing, and dependency caching.
+    - `pkg/nodejs`: Implements Node.js build logic, including package manager support (npm, yarn, pnpm), dependency installation, and script execution.
+    - `pkg/php`: Provides PHP build logic, with support for Composer. It handles dependency installation and configuration.
+    - `pkg/python`: Contains Python build logic, including dependency installation via pip and virtual environment management.
+    - `pkg/ruby`: Implements Ruby build logic, with support for Bundler. It handles Gemfile parsing and dependency installation.
+    - `pkg/dotnet`: Provides .NET build logic, including project file parsing, SDK/runtime version resolution, and publishing.
+    - `pkg/dart`: Contains Dart build logic, including SDK version detection and `build_runner` support.
+- **Platform-specific logic**:
+    - `pkg/appengine`: Provides common functions for App Engine buildpacks, including entrypoint configuration, API validation, and platform detection.
+    - `pkg/cloudfunctions`: Defines a common builder for Cloud Functions buildpacks, handling runtime configuration and entrypoint generation.
+    - `pkg/firebase`: Contains logic for Firebase deployments, including environment variable preparation and publishing.
+    - `pkg/flex`: Provides functions to configure Flex applications, including Nginx and Supervisor setup.
+- **Common libraries**:
+    - `pkg/appstart`: Creates the `app_start.json` config file for defining the application's entrypoint.
+    - `pkg/appyaml`: Handles `app.yaml` configuration files for App Engine.
+    - `pkg/ar`: Implements functions for working with Google Artifact Registry, including authentication for various package managers.
+    - `pkg/buildererror`: Defines a structured error format for buildpacks.
+    - `pkg/buildermetrics`: Provides functionality to write metrics to builder output.
+    - `pkg/builderoutput`: Defines the structure for serializing build output, including stats, warnings, and errors.
+    - `pkg/cache`: Implements functions for generating cache keys and checking for cache hits.
+    - `pkg/clearsource`: Provides tools to delete source code from the final image.
+    - `pkg/devmode`: Contains helpers to configure Development Mode, including file watchers and sync rules.
+    - `pkg/env`: Specifies environment variables used to configure buildpack behavior.
+    - `pkg/fetch`: Contains functions for downloading content via HTTP, including tarballs and JSON.
+    - `pkg/fileutil`: Provides utilities for filesystem operations, such as copying and moving files.
+    - `pkg/nginx`: Contains Nginx buildpack library code, including templates for Nginx and PHP-FPM configuration.
+    - `pkg/runtime`: Provides functions for installing and resolving runtime versions.
+    - `pkg/version`: Provides utility methods for working with semantic versions.
+    - `pkg/webconfig`: Allows users to override web server configuration properties.
+
+### `builders/`
+
+This directory contains the configuration for the builders. Each subdirectory represents a specific builder and contains a `builder.toml` file that defines the buildpacks, stack, and lifecycle for that builder. The `builder.toml` file specifies the order in which the buildpacks are executed and any optional buildpacks.
+
+- **Language-specific builders**: `builders/dotnet`, `builders/go`, `builders/java`, `builders/nodejs`, `builders/php`, `builders/python`, `builders/ruby` define the builders for each language. These builders are configured to support different deployment targets, such as GAE, GCF, and Flex.
+- **Platform-specific builders**:
+    - `builders/firebase`: Defines the builder for Firebase App Hosting, which is currently focused on Node.js applications.
+    - `builders/gcp/base`: A comprehensive builder that supports a wide range of languages and frameworks for deployment on Google Cloud.
+- **Templates**: Some builders, like `java` and `python`, use `builder.toml.template` files. These templates are used to generate the final `builder.toml` with specific stack information during the build process.
+

--- a/builders/ruby/acceptance/runtime.bzl
+++ b/builders/ruby/acceptance/runtime.bzl
@@ -9,6 +9,7 @@ gae_runtimes = {
     "ruby30": "3.0.7",
     "ruby32": "3.2.6",
     "ruby33": "3.3.7",
+    "ruby34": "3.4.0",
 }
 
 gcf_runtimes = {
@@ -17,9 +18,11 @@ gcf_runtimes = {
     "ruby30": "3.0.7",
     "ruby32": "3.2.6",
     "ruby33": "3.3.7",
+    "ruby34": "3.4.0",
 }
 
 flex_runtimes = {
     "ruby32": "3.2.6",
     "ruby33": "3.3.7",
+    "ruby34": "3.4.0",
 }

--- a/cmd/ruby/bundle/BUILD.bazel
+++ b/cmd/ruby/bundle/BUILD.bazel
@@ -36,8 +36,12 @@ go_binary(
 go_test(
     name = "main_test",
     size = "small",
-    srcs = ["main_test.go"],
+    srcs = ["main_test.go", "main_build_test.go"],
     embed = [":main"],
     rundir = ".",
-    deps = ["//internal/buildpacktest"],
+    deps = [
+        "//internal/buildpacktest",
+        "//internal/mockprocess",
+        "//pkg/ruby",
+    ],
 )

--- a/cmd/ruby/bundle/main_build_test.go
+++ b/cmd/ruby/bundle/main_build_test.go
@@ -1,0 +1,97 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"testing"
+	"os"
+
+	buildpacktest "github.com/GoogleCloudPlatform/buildpacks/internal/buildpacktest"
+	"github.com/GoogleCloudPlatform/buildpacks/internal/mockprocess"
+	"github.com/GoogleCloudPlatform/buildpacks/pkg/ruby"
+)
+
+func TestBuild(t *testing.T) {
+	testCases := []struct {
+		name              string
+		rubyVersion       string
+		wantCommands      []*mockprocess.ExecRe
+	}{
+		{
+			name:        "ruby 3.4.0 installs bundled gems",
+			rubyVersion: "3.4.0",
+			wantCommands: []*mockprocess.ExecRe{
+				mockprocess.NewExecRe(t, `gem install bigdecimal`),
+				mockprocess.NewExecRe(t, `gem install cgi`),
+				mockprocess.NewExecRe(t, `gem install csv`),
+				mockprocess.NewExecRe(t, `gem install drb`),
+				mockprocess.NewExecRe(t, `gem install fcntl`),
+				mockprocess.NewExecRe(t, `gem install fileutils`),
+				mockprocess.NewExecRe(t, `gem install find`),
+				mockprocess.NewExecRe(t, `gem install ftools`),
+				mockprocess.NewExecRe(t, `gem install getoptlong`),
+				mockprocess.NewExecRe(t, `gem install io-console`),
+				mockprocess.NewExecRe(t, `gem install io-nonblock`),
+				mockprocess.NewExecRe(t, `gem install io-wait`),
+				mockprocess.NewExecRe(t, `gem install irb`),
+				mockprocess.NewExecRe(t, `gem install logger`),
+				mockprocess.NewExecRe(t, `gem install mutex_m`),
+				mockprocess.NewExecRe(t, `gem install net-ftp`),
+				mockprocess.NewExecRe(t, `gem install net-http`),
+				mockprocess.NewExecRe(t, `gem install net-imap`),
+				mockprocess.NewExecRe(t, `gem install net-pop`),
+				mockprocess.NewExecRe(t, `gem install net-protocol`),
+				mockprocess.NewExecRe(t, `gem install open-uri`),
+				mockprocess.NewExecRe(t, `gem install optparse`),
+				mockprocess.NewExecRe(t, `gem install pp`),
+				mockprocess.NewExecRe(t, `gem install prettyprint`),
+				mockprocess.NewExecRe(t, `gem install rdoc`),
+				mockprocess.NewExecRe(t, `gem install readline`),
+				mockprocess.NewExecRe(t, `gem install reline`),
+				mockprocess.NewExecRe(t, `gem install resolv`),
+				mockprocess.NewExecRe(t, `gem install rinda`),
+				mockprocess.NewExecRe(t, `gem install securerandom`),
+				mockprocess.NewExecRe(t, `gem install set`),
+				mockprocess.NewExecRe(t, `gem install tempfile`),
+				mockprocess.NewExecRe(t, `gem install time`),
+				mockprocess.NewExecRe(t, `gem install tmpdir`),
+				mockprocess.NewExecRe(t, `gem install tracer`),
+				mockprocess.NewExecRe(t, `gem install un`),
+				mockprocess.NewExecRe(t, `gem install uri`),
+				mockprocess.NewExecRe(t, `gem install weakref`),
+				mockprocess.NewExecRe(t, `gem install win32ole`),
+				mockprocess.NewExecRe(t, `gem install yaml`),
+			},
+		},
+		{
+			name:        "ruby 3.3.0 does not install bundled gems",
+			rubyVersion: "3.3.0",
+			wantCommands:      []*mockprocess.ExecRe{},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			os.Setenv(ruby.RubyVersionKey, tc.rubyVersion)
+			defer os.Unsetenv(ruby.RubyVersionKey)
+
+			opts := []buildpacktest.Option{
+				buildpacktest.WithTestName(tc.name),
+				buildpacktest.WithExecMock(tc.wantCommands...),
+			}
+
+			buildpacktest.TestBuild(t, buildFn, opts...)
+		})
+	}
+}


### PR DESCRIPTION
This PR updates the Ruby buildpack to support Ruby 3.4. The main change is to install the bundled gems that are no longer part of the standard library in Ruby 3.4. This PR also updates the acceptance tests to include Ruby 3.4.