### PR TITLE
feat(ruby): Add base64 gem for Ruby 3.4 support

### DIFF
--- a/builders/testdata/ruby/generic/simple/Gemfile
+++ b/builders/testdata/ruby/generic/simple/Gemfile
@@ -16,3 +16,6 @@ source "https://rubygems.org"
 
 gem "sinatra", "~> 2.1"
 gem "webrick", "~> 1.7"
+if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.4.0')
+    gem "base64"
+end


### PR DESCRIPTION
This PR adds the base64 gem to the Gemfile for Ruby 3.4+ to ensure backward compatibility.